### PR TITLE
ci(travis): Add Alpine version verification to build script. (#3)

### DIFF
--- a/sh/ci/build.sh
+++ b/sh/ci/build.sh
@@ -18,3 +18,30 @@ docker build --build-arg ALPINE_VERSION=$ALPINE_VERSION --tag $DOCKER_IMAGE_NAME
 
 # test the image size
 $DOCKER_UTIL_PATH/sh/test-image-size.sh -i $DOCKER_IMAGE_NAME -t $IMAGE_SIZE_THRESHOLD
+
+# get the Alpine version from the container
+CONTAINER_ALPINE_VERSION=$(docker run --entrypoint cat --rm $DOCKER_IMAGE_NAME /etc/alpine-release)
+
+# remove anything past <major>.<minor>
+NORMALIZED_CONTAINER_ALPINE_VERSION=`expr "$CONTAINER_ALPINE_VERSION" : '\([0-9]*\.[0-9]*\)'`
+
+# normalize the expected version to an actual version, not the name of a tag
+case $ALPINE_VERSION in
+  edge)
+    EXPECTED_ALPINE_VERSION=3.6
+    ;;
+  latest)
+    EXPECTED_ALPINE_VERSION=3.6
+    ;;
+  *)
+    EXPECTED_ALPINE_VERSION=$ALPINE_VERSION
+    ;;
+esac
+
+# validate Alpine version (<major.<minor> only)
+if [ $NORMALIZED_CONTAINER_ALPINE_VERSION = $EXPECTED_ALPINE_VERSION ]; then
+  echo "Passed: The normalized Alpine version ${NORMALIZED_CONTAINER_ALPINE_VERSION} matches the expected version."
+else
+  echo "Failed: The normalized Alpine version ${NORMALIZED_CONTAINER_ALPINE_VERSION} does not match the expected version ${EXPECTED_ALPINE_VERSION}."
+  exit 1
+fi


### PR DESCRIPTION
Note: Alpine declares the edge version to be the same as latest.