### PR TITLE
ci(travis): Disable image comparison until we can work out the difference between the failing Travis build and passing local build. (#8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ stages:
   - name: Stage Image
     if: branch = stage AND type = push
   - name: Compare Build to Stage
-    if: branch = master AND type = push
+    if: branch = master AND type = push AND env(COMPARE_BUILD_TO_STAGE) IS present
   - name: Promote Stage to Prod
     if: branch = master AND type = push
 


### PR DESCRIPTION
See https://travis-ci.org/beeglercorp/Dockerfile-travis-cli/jobs/303717256#L835-L842